### PR TITLE
Added dependency_validator to CI

### DIFF
--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Analyze code
         run: dart analyze --fatal-infos
+
+      - name: Validate dependencies
+        run: dart run dependency_validator

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
+      sha256: "03f6da266a27a4538a69295ec142cb5717d7d4e5727b84658b63e1e1509bac9c"
       url: "https://pub.dev"
     source: hosted
-    version: "76.0.0"
+    version: "79.0.0"
   _macros:
     dependency: transitive
     description: dart
@@ -26,10 +26,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
+      sha256: c9040fc56483c22a5e04a9f6a251313118b1a3c42423770623128fa484115643
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.0"
+    version: "7.2.0"
   ansi_regex:
     dependency: transitive
     description:
@@ -78,6 +78,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  build_config:
+    dependency: transitive
+    description:
+      name: build_config
+      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   characters:
     dependency: transitive
     description:
@@ -154,10 +162,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "7856d364b589d1f08986e140938578ed36ed948581fbc3bc9aef1805039ac5ab"
+      sha256: "27eb0ae77836989a3bc541ce55595e8ceee0992807f14511552a898ddd0d88ac"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.7"
+    version: "3.0.1"
   dartcv4:
     dependency: transitive
     description:
@@ -166,6 +174,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  dependency_validator:
+    dependency: "direct dev"
+    description:
+      name: dependency_validator
+      sha256: "3a243f5b9def5f902887a66fbea7e72e612eee956af6c8c34d382fe6d5484145"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   dhttpd:
     dependency: "direct main"
     description:
@@ -207,13 +223,14 @@ packages:
     source: hosted
     version: "2.1.3"
   ffigen:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: ffigen
-      sha256: "2119b4fe3aad0db94dc9531b90283c4640a6231070e613c400b426a4da08c704"
-      url: "https://pub.dev"
-    source: hosted
-    version: "16.1.0"
+      path: "pkgs/ffigen"
+      ref: HEAD
+      resolved-ref: "6456d48324dcd9ddc8907c073f56f682ddc519ff"
+      url: "https://github.com/dart-lang/native"
+    source: git
+    version: "17.0.0-wip"
   file:
     dependency: transitive
     description:
@@ -295,7 +312,7 @@ packages:
     source: hosted
     version: "0.3.0+1"
   logger:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: logger
       sha256: be4b23575aac7ebf01f225a241eb7f6b5641eeaf43c6a8613510fc2f8cf187d1
@@ -559,7 +576,7 @@ packages:
     source: hosted
     version: "6.0.0"
   very_good_analysis:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: very_good_analysis
       sha256: "1fb637c0022034b1f19ea2acb42a3603cbd8314a470646a59a2fb01f5f3a8629"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,9 +10,18 @@ workspace:
   - video
 
 dependencies:
-  very_good_analysis: ^6.0.0
   pubspec_parse: ^1.5.0
   args: ^2.6.0
-  logger: ^2.5.0
   dhttpd: ^4.1.0
   cli_spin: ^1.0.1
+  yaml: any
+
+dev_dependencies:
+  dependency_validator: ^5.0.2
+  very_good_analysis: ^6.0.0
+
+dependency_overrides:
+  ffigen:
+    git:
+      url: https://github.com/dart-lang/native
+      path: pkgs/ffigen

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,6 @@ dependencies:
   args: ^2.6.0
   dhttpd: ^4.1.0
   cli_spin: ^1.0.1
-  yaml: any
 
 dev_dependencies:
   dependency_validator: ^5.0.2


### PR DESCRIPTION
From now on, all PRs must be careful not to add packages that we are not using, and to always properly declare packages they use in their pubspec. This CI check will go a bit beyond what Pub will already do. 