### PR TITLE
Improve Subsystems safety

### DIFF
--- a/subsystems/lib/src/devices/firmware.dart
+++ b/subsystems/lib/src/devices/firmware.dart
@@ -26,11 +26,52 @@ final nameToDevice = <String, Device>{
 /// service is responsible for routing incoming UDP messages to the correct firmware device
 /// ([_sendToSerial]), and forwarding serial messages to the Dashboard ([RoverSocket.sendWrapper]).
 class FirmwareManager extends Service {
+  /// The amount of time to wait before automatically sending a
+  /// stop command to the firmware after not receiving messages
+  static const Duration firmwareStopTimeout = Duration(milliseconds: 500);
+
   /// Subscriptions to each of the firmware devices.
   final List<StreamSubscription<WrappedMessage>> _subscriptions = [];
 
   /// A list of firmware devices attached to the rover.
   List<BurtFirmwareSerial> devices = [];
+
+  /// A map of devices to their timers to automatically shut
+  /// off if no new messages are received
+  /// 
+  /// This prevents a scenario where commands aren't sent
+  /// from the dashboard, and that program disconnects, leaving
+  /// the motors to run freely
+  final Map<Device, Timer> deviceStopTimers = {};
+
+  /// The current status of the rover, as received from [UpdateSetting]
+  RoverStatus currentStatus = RoverStatus.MANUAL;
+
+  /// Whether or not the firmware should be sent any messages, the firmware
+  /// should only be instructed to move when [currentStatus] is either [RoverStatus.AUTONOMOUS]
+  /// or [RoverStatus.MANUAL]
+  bool get shouldMove =>
+      currentStatus == RoverStatus.AUTONOMOUS ||
+      currentStatus == RoverStatus.MANUAL;
+
+  StreamSubscription<UpdateSetting>? _roverStatusSubscription;
+
+  /// The command to stop the drive motors
+  final stopDrive = DriveCommand(throttle: 0, setThrottle: true);
+  /// The command to stop the arm
+  final stopArm = ArmCommand(stop: true);
+  /// The command to stop the gripper
+  final stopGripper = GripperCommand(stop: true);
+  /// The command to stop science
+  final stopScience = ScienceCommand(stop: true);
+
+  /// Map of each firmware [Device] to its corresponding stop command
+  late final Map<Device, Message> deviceToStopCommand = {
+    Device.DRIVE: stopDrive,
+    Device.ARM: stopArm,
+    Device.GRIPPER: stopGripper,
+    Device.SCIENCE: stopScience,
+  };
 
   @override
   Future<bool> init() async {
@@ -44,7 +85,28 @@ class FirmwareManager extends Service {
       final subscription = device.messages.listen(collection.server.sendWrapper);
       _subscriptions.add(subscription);
     }
+    currentStatus = RoverStatus.MANUAL;
+
+    _roverStatusSubscription = collection.server.messages.onMessage(
+      name: UpdateSetting().messageName,
+      constructor: UpdateSetting.fromBuffer,
+      callback: onSettingsUpdate,
+    );
     return result;
+  }
+
+  /// Handles an incoming [UpdateSetting] message
+  void onSettingsUpdate(UpdateSetting setting) {
+    if (!setting.hasStatus()) return;
+    final status = setting.status;
+
+    currentStatus = setting.status;
+    
+    if (status == RoverStatus.AUTONOMOUS) {
+      stopDevice(Device.DRIVE);
+    } else if (status != RoverStatus.MANUAL) {
+      stopHardware();
+    }
   }
 
   @override
@@ -55,14 +117,38 @@ class FirmwareManager extends Service {
     for (final device in devices) {
       await device.dispose();
     }
+    await _roverStatusSubscription?.cancel();
+  }
+
+  /// Sends a message to the firmware [device] to stop the device
+  void stopDevice(Device device) {
+    logger.debug("Stopping device $device");
+    final stopCommand = deviceToStopCommand[device];
+    if (stopCommand != null) {
+      sendMessage(stopCommand);
+    }
   }
 
   /// Sends a [WrappedMessage] to the correct Serial device.
   ///
   /// The notes on [sendMessage] apply here as well.
-  void _sendToSerial(WrappedMessage wrapper) {
+  void _sendToSerial(WrappedMessage wrapper, {bool fromNetwork = true}) {
     final device = nameToDevice[wrapper.name];
     if (device == null) return;
+    deviceStopTimers[device]?.cancel();
+    if (fromNetwork) {
+      if (!shouldMove) {
+        logger.debug("Ignoring incoming ${wrapper.name}, status is currently ${currentStatus.name}");
+        return;
+      }
+      deviceStopTimers[device] = Timer(firmwareStopTimeout, () {
+        logger.info(
+          "Device timed out: $device",
+          body: "No commands have been received for ${firmwareStopTimeout.inMilliseconds} milliseconds",
+        );
+        stopDevice(device);
+      });
+    }
     final serial = devices.firstWhereOrNull((s) => s.device == device);
     if (serial == null) return;
     serial.sendBytes(wrapper.data);
@@ -73,5 +159,16 @@ class FirmwareManager extends Service {
   /// This does nothing if the appropriate device is not connected. Specifically, this is not an
   /// error because the Dashboard may be used during testing, when the hardware devices may not be
   /// assembled, connected, or functional yet.
-  void sendMessage(Message message) => _sendToSerial(message.wrap());
+  void sendMessage(Message message, {bool fromNetwork = false}) =>
+      _sendToSerial(message.wrap(), fromNetwork: fromNetwork);
+
+  /// Sends messages to all over the firmware devices to stop all movement
+  /// 
+  /// This is used as a safety stop to prevent any damage to hardware
+  void stopHardware() {
+    stopDevice(Device.DRIVE);
+    stopDevice(Device.ARM);
+    stopDevice(Device.GRIPPER);
+    stopDevice(Device.SCIENCE);
+  }
 }

--- a/subsystems/lib/subsystems.dart
+++ b/subsystems/lib/subsystems.dart
@@ -70,14 +70,7 @@ class SubsystemsCollection extends Service {
   Future<void> onDisconnect() async {
     await super.onDisconnect();
     logger.info("Stopping all hardware");
-    final stopDrive = DriveCommand(throttle: 0, setThrottle: true);
-    final stopArm = ArmCommand(stop: true);
-    final stopGripper = GripperCommand(stop: true);
-    final stopScience = ScienceCommand(stop: true);
-    firmware.sendMessage(stopDrive);
-    firmware.sendMessage(stopArm);
-    firmware.sendMessage(stopGripper);
-    firmware.sendMessage(stopScience);
+    firmware.stopHardware();
   }
 }
 


### PR DESCRIPTION
If no device command is received for 500 ms, the device is automatically stopped. This prevents a scenario where a program (such as autonomy) crashes, and the rover will continue driving since no additional commands are received.

Additionally, the last received rover status of `UpdateSetting` is cached, and no commands will be sent to firmware if the status is not manual or autonomous. This means that even if a command is somehow sent to subsystems while the dashboard is set to idle, the rover will not move.