### PR TITLE
update pip

### DIFF
--- a/lib/all_programs.dart
+++ b/lib/all_programs.dart
@@ -34,7 +34,13 @@ const programs = [
         ["apt-get", "install", "python3-pip", "-y"],
         requiresInternet: true,
       ),
-      ExtraCommand(
+    ExtraCommand(
+        "Update pip",
+        "python3",
+        ["-m", "pip", "install", "--upgrade", "pip"],
+        requiresInternet: true,
+      ),
+            ExtraCommand(
         "Installing dependencies",
         "python3",
         ["-m", "pip", "install", "-r", "requirements.txt", "--break-system-packages"],

--- a/lib/all_programs.dart
+++ b/lib/all_programs.dart
@@ -34,13 +34,13 @@ const programs = [
         ["apt-get", "install", "python3-pip", "-y"],
         requiresInternet: true,
       ),
-    ExtraCommand(
+      ExtraCommand(
         "Update pip",
         "python3",
         ["-m", "pip", "install", "--upgrade", "pip"],
         requiresInternet: true,
       ),
-            ExtraCommand(
+      ExtraCommand(
         "Installing dependencies",
         "python3",
         ["-m", "pip", "install", "-r", "requirements.txt", "--break-system-packages"],


### PR DESCRIPTION
apt on Ubuntu retrieves an old version of pip so it has to be updated to run on the jetson.